### PR TITLE
Fixing naming issues

### DIFF
--- a/ParseUrlModifier.php
+++ b/ParseUrlModifier.php
@@ -16,6 +16,8 @@ class ParseUrlModifier extends Modifier
    */
   public function index($value, $params, $context)
   {
+    $desiredPiece = false;
+    
     if ($param = array_get($params, 0)) {
       $param = array_get($context, $param, $param);
       switch ($param) {
@@ -42,9 +44,6 @@ class ParseUrlModifier extends Modifier
           break;
         case 'fragment':
           $desiredPiece = PHP_URL_FRAGMENT;
-          break;
-        default:
-          $desiredPiece = null;
           break;
       }
     }

--- a/ParseUrlModifier.php
+++ b/ParseUrlModifier.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Statamic\Addons\ParseURL;
+namespace Statamic\Addons\ParseUrl;
 
 use Statamic\Extend\Modifier;
 
-class ParseURLModifier extends Modifier
+class ParseUrlModifier extends Modifier
 {
   /**
    * Modify a value

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Uses PHP's `parse_url` to return specified pieces of a given URL.
 
 ## Installation
 
-1. Move the `statamic-ParseURL` folder to `site/addons/ParseURL` (removing the `statamic-` bit)
+1. Move the `statamic-ParseURL` folder to `site/addons/ParseUrl`, in CamelCase, not capital letters (removing the `statamic-` bit)
 2. `cd` into your site's directory.
 3. Run `php please addons:refresh`
 
@@ -13,7 +13,7 @@ Uses PHP's `parse_url` to return specified pieces of a given URL.
 In your template, call the modifier like this:
 
 ```
-{{ current_url | parseurl:[option] }}
+{{ current_url | parse_url:[option] }}
 ```
 
 … where `[option]` is one of:


### PR DESCRIPTION
On Linux (and supposedly Unix, macOS) Statamic 2.5.9 will not find the Addon's files.

If using the modifier `parseurl` the folder and class names would need to be lowercase as well.

With `parse_url` Statamic will look for `parseurl` and `parseUrl`.